### PR TITLE
removeCorrespondentDevice2

### DIFF
--- a/device.js
+++ b/device.js
@@ -651,6 +651,30 @@ function addIndirectCorrespondents(arrOtherCosigners, onDone){
 	}, onDone);
 }
 
+function removeCorrespondentDevice(addr, onDone){
+	db.query(
+		"DELETE FROM correspondent_devices WHERE device_address=?", 
+		[addr], 
+		function(){
+			db.query(
+				"DELETE FROM device_messages WHERE device_address=?", 
+				[addr], 
+				function(){
+					onDone();
+				}
+			);
+		}
+	);
+}
+
+function readDeviceAddressesUsedInMultisigWallets(onDone){
+	db.query(
+		"SELECT distinct device_address FROM wallet_signing_paths", 
+		function(rows){
+			onDone(rows);
+		}
+	);
+}
 
 // -------------------------------
 // witnesses
@@ -705,5 +729,7 @@ exports.readCorrespondents = readCorrespondents;
 exports.readCorrespondent = readCorrespondent;
 exports.readCorrespondentsByDeviceAddresses = readCorrespondentsByDeviceAddresses;
 exports.updateCorrespondentProps = updateCorrespondentProps;
+exports.removeCorrespondentDevice = removeCorrespondentDevice;
+exports.readDeviceAddressesUsedInMultisigWallets = readDeviceAddressesUsedInMultisigWallets;
 exports.addIndirectCorrespondents = addIndirectCorrespondents;
 exports.getWitnessesFromHub = getWitnessesFromHub;

--- a/wallet.js
+++ b/wallet.js
@@ -148,6 +148,11 @@ function handleMessageFromHub(ws, json, device_pubkey, bIndirectCorrespondent, c
 			callbacks.ifOk();
 			break;
 		
+		case "remove_paired_device":
+			device.removeCorrespondentDevice(from_address, function(){});
+			callbacks.ifOk();
+			break;
+
 		case "create_new_wallet":
 			// {wallet: "base64", wallet_definition_template: [...]}
 			walletDefinedByKeys.handleOfferToCreateNewWallet(body, from_address, callbacks);


### PR DESCRIPTION
- only devices not used in multisig wallets can be removed
- recordsets will be deleted from tables correspondent_devices and device_messages (some missing?)
- peer will be notified