### PR TITLE
Move getSourceString to String Utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ Temporary Items
 Session.vim
 .netrwhist
 *~
+
+# IDEA IntelliJ
+
+*.iml
+.idea
+

--- a/object_hash.js
+++ b/object_hash.js
@@ -3,51 +3,7 @@
 var crypto = require('crypto');
 var _ = require('lodash');
 var chash = require('./chash.js');
-
-function getSourceString(obj) {
-	var arrComponents = [];
-	function extractComponents(variable){
-		if (variable === null)
-			throw Error("null value in "+JSON.stringify(obj));
-		switch (typeof variable){
-			case "string":
-				arrComponents.push("s", variable);
-				break;
-			case "number":
-				arrComponents.push("n", variable.toString());
-				break;
-			case "boolean":
-				arrComponents.push("b", variable.toString());
-				break;
-			case "object":
-				if (Array.isArray(variable)){
-					if (variable.length === 0)
-						throw Error("empty array in "+JSON.stringify(obj));
-					arrComponents.push('[');
-					for (var i=0; i<variable.length; i++)
-						extractComponents(variable[i]);
-					arrComponents.push(']');
-				}
-				else{
-					var keys = Object.keys(variable).sort();
-					if (keys.length === 0)
-						throw Error("empty object in "+JSON.stringify(obj));
-					keys.forEach(function(key){
-						if (typeof variable[key] === "undefined")
-							throw Error("undefined at "+key+" of "+JSON.stringify(obj));
-						arrComponents.push(key);
-						extractComponents(variable[key]);
-					});
-				}
-				break;
-			default:
-				throw Error("hash: unknown type="+(typeof variable)+" of "+variable+", object: "+JSON.stringify(obj));
-		}
-	}
-	
-	extractComponents(obj);
-	return arrComponents.join("\x00");
-}
+var getSourceString = require('./string_utils').getSourceString;
 
 function getChash160(obj) {
 	return chash.getChash160(getSourceString(obj));

--- a/string_utils.js
+++ b/string_utils.js
@@ -1,0 +1,59 @@
+/*jslint node: true */
+"use strict";
+
+const STRING_JOIN_CHAR = "\x00";
+
+/**
+ * Converts the argument into a string by mapping data types to a prefixed string and concatenating all fields together.
+ * @param obj the value to be converted into a string
+ * @returns {string} the string version of the value
+ */
+function getSourceString(obj) {
+    var arrComponents = [];
+    function extractComponents(variable){
+        if (variable === null)
+            throw Error("null value in "+JSON.stringify(obj));
+        switch (typeof variable){
+            case "string":
+                arrComponents.push("s", variable);
+                break;
+            case "number":
+                arrComponents.push("n", variable.toString());
+                break;
+            case "boolean":
+                arrComponents.push("b", variable.toString());
+                break;
+            case "object":
+                if (Array.isArray(variable)){
+                    if (variable.length === 0)
+                        throw Error("empty array in "+JSON.stringify(obj));
+                    arrComponents.push('[');
+                    for (var i=0; i<variable.length; i++)
+                        extractComponents(variable[i]);
+                    arrComponents.push(']');
+                }
+                else{
+                    var keys = Object.keys(variable).sort();
+                    if (keys.length === 0)
+                        throw Error("empty object in "+JSON.stringify(obj));
+                    keys.forEach(function(key){
+                        if (typeof variable[key] === "undefined")
+                            throw Error("undefined at "+key+" of "+JSON.stringify(obj));
+                        arrComponents.push(key);
+                        extractComponents(variable[key]);
+                    });
+                }
+                break;
+            default:
+                throw Error("hash: unknown type="+(typeof variable)+" of "+variable+", object: "+JSON.stringify(obj));
+        }
+    }
+
+    extractComponents(obj);
+    return arrComponents.join(STRING_JOIN_CHAR);
+}
+
+exports.STRING_JOIN_CHAR = STRING_JOIN_CHAR; // for tests
+exports.getSourceString = getSourceString;
+
+

--- a/test/string_utils.test.js
+++ b/test/string_utils.test.js
@@ -1,0 +1,53 @@
+const test = require('ava');
+
+const StringUtils = require('../string_utils');
+
+const STRING_JOIN_CHAR = StringUtils.STRING_JOIN_CHAR;
+const getSourceString = StringUtils.getSourceString;
+
+/**
+ * getSourceString
+ */
+
+const simpleString = 'simple test string';
+const simpleStringResult = ['s', simpleString].join(STRING_JOIN_CHAR);
+test('Test a simple string', t => {
+    t.true(getSourceString(simpleString) === simpleStringResult);
+});
+
+const integer = 27090;
+const simpleIntResult = ['n', integer].join(STRING_JOIN_CHAR);
+test('Test an integer', t => {
+    t.true(getSourceString(integer) === simpleIntResult);
+});
+
+const float = 8.103;
+const simpleFloatResult = ['n', float].join(STRING_JOIN_CHAR);
+test('Test a float', t => {
+    t.true(getSourceString(float) === simpleFloatResult);
+});
+
+const boolean = false;
+const simpleBooleanResult = ['b', boolean].join(STRING_JOIN_CHAR);
+test('Test a boolean', t => {
+    t.true(getSourceString(boolean) === simpleBooleanResult);
+});
+
+const arrayInput = ['a', 81, 'b', 'c', 3.6903690369, true];
+const arrayInputResultPairs = ['s', 'n', 's', 's', 'n', 'b'].map(function(typ, idx) {
+    return [typ, arrayInput[idx]].join(STRING_JOIN_CHAR);
+}).join(STRING_JOIN_CHAR);
+const arrayInputResult = ['[', arrayInputResultPairs, ']'].join(STRING_JOIN_CHAR);
+test('Test an array', t => {
+    t.true(getSourceString(arrayInput) === arrayInputResult);
+});
+
+// Just hard-coding this...
+const object = {unit: 'cluster', bunch: 9, witness: {name: 'axe', index: 18}};
+const objectPairs = ['bunch', getSourceString(9), 'unit', getSourceString('cluster'), 'witness', 'index', getSourceString(18), 'name', getSourceString('axe')];
+const objectResult = objectPairs.join(STRING_JOIN_CHAR);
+test('Test an object', t => {
+    t.true(getSourceString(object) === objectResult);
+});
+
+

--- a/test/validation_utils.test.js
+++ b/test/validation_utils.test.js
@@ -1,7 +1,7 @@
 const test = require('ava');
 const { check, gen, property } = require('testcheck');
 
-var ValidationUtils = require("./validation_utils.js");
+var ValidationUtils = require("../validation_utils.js");
 
 /**
  * hasFieldsExcept


### PR DESCRIPTION
This commit is a non-functional change.

It moves the getSourceString function into its own string_utils module.
Additionally, a new string_utils test is added to check the functionality.

Lastly, it moves the test files into a new sub-directory named `/test`.

**Tested: Locally**
- Ran the test file and verified new tests pass
- Ran all tests in the `/test` directory and verified they all pass.

**Example output**
```
$ node node_modules/ava/cli.js test/string_utils.test.js 

  6 passed
```
and all tests:
```
$ node node_modules/ava/cli.js test/*.test.js

  18 passed
```