### PR TITLE
fixed so a genesis unit with a single author can be created

### DIFF
--- a/composer.js
+++ b/composer.js
@@ -653,7 +653,11 @@ function composeJoint(params){
 			var naked_payload_commission = objectLength.getTotalPayloadSize(objUnit); // without input coins
 
 			if (bGenesis){
-				objPaymentMessage.payload.inputs = [{type: "issue", serial_number: 1, amount: constants.TOTAL_WHITEBYTES, address: arrWitnesses[0]}];
+				var issueInput = {type: "issue", serial_number: 1, amount: constants.TOTAL_WHITEBYTES};
+				if (objUnit.authors.length > 1) {
+					issueInput.address = arrWitnesses[0];
+				}
+				objPaymentMessage.payload.inputs = [issueInput];
 				objUnit.payload_commission = objectLength.getTotalPayloadSize(objUnit);
 				total_input = constants.TOTAL_WHITEBYTES;
 				return cb();


### PR DESCRIPTION
In a scenario, when the genesis unit is created with one author only, the unit creation fails with the error below. This merge request fixes it.

```
Error: Validation error: when single-authored, must not put address in issue input
    at Error (native)
    at Object.onError (/home/ubuntu/workspace/create.js:7:11)
    at Object.ifUnitError (/home/ubuntu/workspace/node_modules/byteballcore/composer.js:819:16)
    at /home/ubuntu/workspace/node_modules/byteballcore/validation.js:237:18
    at Statement.<anonymous> (/home/ubuntu/workspace/node_modules/byteballcore/sqlite_pool.js:138:6)
```