### PR TITLE
Fixes 'missing fields' error in message_from_hub event  

### DIFF
--- a/network.js
+++ b/network.js
@@ -2303,7 +2303,10 @@ function handleRequest(ws, tag, command, params){
 			// if i'm always online and i'm my own hub
 			if (bToMe){
 				sendResponse(ws, tag, "accepted");
-				eventBus.emit("message_from_hub", ws, 'hub/message', objDeviceMessage);
+				eventBus.emit("message_from_hub", ws, 'hub/message', {
+					message_hash: objectHash.getBase64Hash(objDeviceMessage),
+					message: objDeviceMessage
+				});
 				return;
 			}
 			


### PR DESCRIPTION
fixed `'missing fields'` error in `message_from_hub` event when the running process is its own hub and the message is delivered to it.

The message structure that is expected in the `wallet.js` is slightly different for the message_from_hub event than what is placed in the eventBus in `network.js`. The `wallet.js` expects an 'envelope' object with the message and a message hash fields, while the `network.js` only passes the message itself.