### PR TITLE
Including text messages in asset payments

### DIFF
--- a/divisible_asset.js
+++ b/divisible_asset.js
@@ -182,7 +182,7 @@ function composeDivisibleAssetPaymentJoint(params){
 		signing_addresses: params.signing_addresses,
 		minimal: params.minimal,
 		outputs: arrBaseOutputs,
-		
+		messages:params.messages,
 		// function that creates additional messages to be added to the joint
 		retrieveMessages: function(conn, last_ball_mci, bMultiAuthored, arrPayingAddresses, onDone){
 			var arrAssetPayingAddresses = _.intersection(arrPayingAddresses, params.paying_addresses);


### PR DESCRIPTION
Added the possibility to specify additional information about an asset payment. In this way it becomes possible to relate a unit to an invoice.