### PR TITLE
Enhance the pairing_attempt event

### DIFF
--- a/device.js
+++ b/device.js
@@ -587,7 +587,7 @@ function handlePairingMessage(json, device_pubkey, callbacks){
 		return callbacks.ifError("no device_name when pairing");
 	if ("reverse_pairing_secret" in body && !ValidationUtils.isNonemptyString(body.reverse_pairing_secret))
 		return callbacks.ifError("bad reverse pairing secret");
-	eventBus.emit("pairing_attempt", from_address, body.pairing_secret);
+	eventBus.emit("pairing_attempt", device_pubkey, json);
 	db.query(
 		"SELECT is_permanent FROM pairing_secrets WHERE pairing_secret=? AND expiry_date > "+db.getNow(), 
 		[body.pairing_secret], 


### PR DESCRIPTION
The previously passed parameters could actually have been fetched from the `json` variable. Passing the `device_pubkey` and `json` variables directly to the `pairing_attempt` event gives the subscribers of that event the maximum power over the program flow. For example, this makes it really convenient to accept pairing requests that use unknown pairing codes (see the code below for a potential use case in chat bots).

```javascript
    events.on('pairing_attempt', function (device_pubkey, json) {
        var device_addr = objhash.getDeviceAddress(device_pubkey);
        var secret = json.body.pairing_secret;
        alert("Pairing attempt from "+device_addr+" ("+secret+").");
        json.body.pairing_secret = config.permanent_pairing_secret;
        // Now we can authenticate the user's web session based on the
        // secret they used when making the pairing request. The web
        // server does not have to be able to make requests to the chat
        // bot. The chat bot notifies the web server about pairing attempts
        // and their respective pairing codes.
    });
```

The above code is executed on all pairing attempts. However, it overwrites the provided pairing secret with a known and permanent pairing code to make sure that all pairing attempts succeed. In addition, we can easily authenticate the client on our website based on the pairing secret that they initially provided (even though it does not exist in our `pairing_secrets` table).