### PR TITLE
catch exception for decipher.final()

### DIFF
--- a/device.js
+++ b/device.js
@@ -330,7 +330,11 @@ function decryptPackage(objEncryptedPackage){
 	}
 	var decrypted1 = Buffer.concat(arrChunks);
 	arrChunks = null;
-	var decrypted2 = decipher.final();
+	try {
+		var decrypted2 = decipher.final();
+	} catch(e) {
+		return console.log("Failed to decrypt package: " + e);
+	}
 	breadcrumbs.add("decrypted lengths: "+decrypted1.length+" + "+decrypted2.length);
 	var decrypted_message_buf = Buffer.concat([decrypted1, decrypted2]);
 	var decrypted_message = decrypted_message_buf.toString("utf8");


### PR DESCRIPTION
decipher.final() throws an exception when authtag is wrong. Catching the exception prevents a malicious correspondent to provoke a crash by sending a wrong tag.